### PR TITLE
Corrected the mode of opening a file for write via csv.writer.

### DIFF
--- a/sovrin_node/server/upgrade_log.py
+++ b/sovrin_node/server/upgrade_log.py
@@ -58,7 +58,7 @@ class UpgradeLog:
         now = datetime.utcnow()
         event = (now, type, when, version)
 
-        with open(self.__filePath, mode="a+") as file:
+        with open(self.__filePath, mode="a+", newline="") as file:
             writer = csv.writer(file, delimiter=self.__delimiter)
             writer.writerow(event)
         self.__items.append(event)


### PR DESCRIPTION
This fixed the following tests which had previously failed on Windows 10:
- test_update_log,
- testNodeDetectsUpgradeDone,
- testSendNodeUpgradeToAllNodes,
- testNodeSchedulesUpgradeAfterRestart.