### PR TITLE
tests pass on the minimal configuration, SOV-1026

### DIFF
--- a/sovrin_node/test/suspension/helper.py
+++ b/sovrin_node/test/suspension/helper.py
@@ -1,0 +1,60 @@
+from plenum.test import waits
+from sovrin_client.test.helper import checkNacks
+from sovrin_common.constants import NULL
+from sovrin_common.identity import Identity
+from stp_core.loop.eventually import eventually
+
+
+def sendIdentityRequest(actingClient, actingWallet, idy):
+    idr = idy.identifier
+    if actingWallet.getTrustAnchoredIdentity(idr):
+        actingWallet.updateTrustAnchoredIdentity(idy)
+    else:
+        actingWallet.addTrustAnchoredIdentity(idy)
+    reqs = actingWallet.preparePending()
+    actingClient.submitReqs(*reqs)
+    return reqs
+
+
+def sendChangeVerkey(actingClient, actingWallet, idr, verkey):
+    idy = Identity(identifier=idr, verkey=verkey)
+    return sendIdentityRequest(actingClient, actingWallet, idy)
+
+
+def sendSuspendRole(actingClient, actingWallet, did):
+    idy = Identity(identifier=did, role=NULL)
+    return sendIdentityRequest(actingClient, actingWallet, idy)
+
+
+def checkIdentityRequestFailed(looper, client, req, cause):
+    timeout = waits.expectedReqNAckQuorumTime()
+    looper.run(eventually(checkNacks,
+                          client,
+                          req.reqId,
+                          cause, retryWait=1, timeout=timeout))
+
+
+def checkIdentityRequestSucceed(looper, actingClient, actingWallet, idr):
+    def chk():
+        assert actingWallet.getTrustAnchoredIdentity(idr).seqNo is not None
+    timeout = waits.expectedTransactionExecutionTime(
+        len(actingClient.nodeReg)
+    )
+    looper.run(eventually(chk, retryWait=1, timeout=timeout))
+
+
+def changeVerkey(looper, actingClient, actingWallet, idr, verkey,
+                 nAckReasonContains=None):
+    reqs = sendChangeVerkey(actingClient, actingWallet, idr, verkey)
+    if not nAckReasonContains:
+        checkIdentityRequestSucceed(looper, actingClient, actingWallet, idr)
+    else:
+        checkIdentityRequestFailed(looper, actingClient, reqs[0], nAckReasonContains)
+
+
+def suspendRole(looper, actingClient, actingWallet, idr, nAckReasonContains=None):
+    reqs = sendSuspendRole(actingClient, actingWallet, idr)
+    if not nAckReasonContains:
+        checkIdentityRequestSucceed(looper, actingClient, actingWallet, idr)
+    else:
+        checkIdentityRequestFailed(looper, actingClient, reqs[0], nAckReasonContains)

--- a/sovrin_node/test/suspension/test_suspension.py
+++ b/sovrin_node/test/suspension/test_suspension.py
@@ -100,15 +100,6 @@ def testTrusteeSuspensionByTrustee(looper, trustee, trusteeWallet,
                 nAckReasonContains='is neither Trustee nor owner of')
 
 
-def testValidatorSuspensionByTrustee(trustee, trusteeWallet, looper, nodeSet):
-    node = nodeSet[-1]
-    nodeNym = hexToFriendly(node.nodestack.verhex)
-    suspendNode(looper, trustee, trusteeWallet, nodeNym, node.name)
-    for n in nodeSet[:-1]:
-        looper.run(eventually(checkNodeNotInNodeReg, n, node.name))
-    looper.run(eventually(checkNodeNotInNodeReg, trustee, node.name))
-    
-
 def testTrusteeCannotChangeVerkey(trustee, trusteeWallet, looper, nodeSet,
                                   anotherTrustee, anotherTGB, anotherSteward,
                                   anotherTrustAnchor):
@@ -117,11 +108,17 @@ def testTrusteeCannotChangeVerkey(trustee, trusteeWallet, looper, nodeSet,
         _, wallet = identity
         changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, '',
                      nAckReasonContains='cannot update verkey')
-        # with pytest.raises(AssertionError):
-        #     _, wallet = identity
-        #     changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, '')
-        # Identity owner can change verkey
+        # Owner can change verkey
         changeVerkey(looper, *identity, wallet.defaultId, '')
-        #sendChangeVerkey(*identity, wallet.defaultId, '')
-        #checkIdentityRequestSucceed(looper, *identity, wallet.defaultId)
-        # changeVerkey(looper, *identity, wallet.defaultId, '')
+
+
+# The test suspends a node, this action affects on other tests.
+# The test has to be the last in this module. It is not a good way.
+# TODO testValidatorSuspensionByTrustee should not affect on other tests
+def testValidatorSuspensionByTrustee(trustee, trusteeWallet, looper, nodeSet):
+    node = nodeSet[-1]
+    nodeNym = hexToFriendly(node.nodestack.verhex)
+    suspendNode(looper, trustee, trusteeWallet, nodeNym, node.name)
+    for n in nodeSet[:-1]:
+        looper.run(eventually(checkNodeNotInNodeReg, n, node.name))
+    looper.run(eventually(checkNodeNotInNodeReg, trustee, node.name))

--- a/sovrin_node/test/suspension/test_suspension.py
+++ b/sovrin_node/test/suspension/test_suspension.py
@@ -1,13 +1,15 @@
 import pytest
 
+from sovrin_node.test.suspension.helper import sendChangeVerkey, checkIdentityRequestFailed, \
+    checkIdentityRequestSucceed, sendSuspendRole, changeVerkey, suspendRole
 from stp_core.loop.eventually import eventually
 from plenum.common.constants import TRUSTEE, STEWARD
 from plenum.common.util import randomString, hexToFriendly
 from plenum.test.pool_transactions.helper import suspendNode
 from plenum.test.pool_transactions.test_suspend_node import \
     checkNodeNotInNodeReg
-from sovrin_client.test.helper import addRole, suspendRole, \
-    getClientAddedWithRole, changeVerkey
+from sovrin_client.test.helper import addRole, \
+    getClientAddedWithRole
 from sovrin_common.constants import TGB, TRUST_ANCHOR
 
 whitelist = ['Observer threw an exception', 'while verifying message']
@@ -88,11 +90,14 @@ def testTrustAnchorSuspensionByTrustee(looper, anotherTrustee, anotherTrustAncho
 
 def testTrusteeSuspensionByTrustee(looper, trustee, trusteeWallet,
                                    anotherTrustee, anotherSteward1):
+    # trustee suspension by trustee is succeed
     trClient, trWallet = anotherTrustee
     suspendRole(looper, trustee, trusteeWallet, trWallet.defaultId)
+
+    # trustee suspension by steward1 is failed
     _, sWallet = anotherSteward1
-    with pytest.raises(AssertionError):
-        suspendRole(looper, trClient, trWallet, sWallet.defaultId)
+    suspendRole(looper, trClient, trWallet, sWallet.defaultId,
+                nAckReasonContains='is neither Trustee nor owner of')
 
 
 def testValidatorSuspensionByTrustee(trustee, trusteeWallet, looper, nodeSet):
@@ -109,8 +114,14 @@ def testTrusteeCannotChangeVerkey(trustee, trusteeWallet, looper, nodeSet,
                                   anotherTrustAnchor):
     for identity in (anotherTrustee, anotherTGB, anotherSteward, anotherTrustAnchor):
         # Trustee cannot change verkey
-        with pytest.raises(AssertionError):
-            _, wallet = identity
-            changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, '')
+        _, wallet = identity
+        changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, '',
+                     nAckReasonContains='cannot update verkey')
+        # with pytest.raises(AssertionError):
+        #     _, wallet = identity
+        #     changeVerkey(looper, trustee, trusteeWallet, wallet.defaultId, '')
         # Identity owner can change verkey
         changeVerkey(looper, *identity, wallet.defaultId, '')
+        #sendChangeVerkey(*identity, wallet.defaultId, '')
+        #checkIdentityRequestSucceed(looper, *identity, wallet.defaultId)
+        # changeVerkey(looper, *identity, wallet.defaultId, '')


### PR DESCRIPTION
- had to re-implement some test helpers from sovrin-client (`changeVerkey` and `suspendRole`) because waiting `with pytest.raises` takes time rather nacks can be checked. `changeVerkey` and `suspendRole` are used only in sovrin-node and can be removed from sovrin-client later. Next `addRole` can be re-implement in 'check-nacks' approach but it is not in scope
- fix random fail of the testTrusteeCannotChangeVerkey test

